### PR TITLE
Add openssl to sfdx image

### DIFF
--- a/sfdx/Dockerfile
+++ b/sfdx/Dockerfile
@@ -2,3 +2,7 @@ FROM theconversation/node AS ci
 
 # Install the SFDX CLI client for SalesForce
 RUN npm install --global sfdx-cli@6.37.0
+
+# Install openssl for decrypting JWT auth keys
+RUN apk add --no-cache openssl
+


### PR DESCRIPTION
We need it in order to be able to decrypt the JWT auth keys which we will use to connect the CI docker image to SalesForce.