### PR TITLE
TC-457 Refactor node dockerfile

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,7 +1,4 @@
 FROM theconversation/base
 
 # Install node.
-RUN apk --no-cache add nodejs nodejs-npm
-
-# Update npm to 6.x.x (for npm audit).
-RUN npm install -g npm@6.4.1
+RUN apk --no-cache add npm nodejs


### PR DESCRIPTION
This PR refactors the node `Dockerfile` to not manually upgrade npm, as it is already up-to-date in the npm package.

## How to Test

* `make node`
* `docker run --rm -ti node npm -v`

You should see that the installed version of `npm` is `6.4.1` :tada: