### PR TITLE
TC-559 Upgrade base image to alpine 3.9

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 # Install core packages.
 RUN apk --no-cache add curl git jq libbz2 libpq libxml2 zlib


### PR DESCRIPTION
This PR upgrades the base alpine image to 3.9. This [release](https://alpinelinux.org/posts/Alpine-3.9.0-released.html) includes a new kernel, and bumped versions of ruby (2.5.3) and nodejs (10.14.2).