### PR TITLE
Upgrade alpine to 3.9.4 in base image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.9.4
 
 # Install core packages.
 RUN apk --no-cache add curl git jq libbz2 libpq libxml2 zlib


### PR DESCRIPTION
This PR upgrades alpine to 3.9.4 in our base docker image.

There have been a [few patch releases](https://alpinelinux.org) since 3.9.0, which mostly contain security updates. Alpine doesn't do big package upgrades in its patch releases, so this update shouldn't break anything.

I also locked alpine to 3.9.4, so that we are very explicit about which release are using.