### PR TITLE
Upgrade base images to Alpine 3.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,19 +3,20 @@
 all: base ruby node sfdx
 
 base:
-	cd base; docker build -t base .
+	pwd
+	cd ./base; docker build -t base .
 	docker tag base theconversation/base:latest
 
 node:
-	cd node; docker build -t node .
+	cd ./node; docker build -t node .
 	docker tag node theconversation/node:latest
 
 ruby:
-	cd ruby; docker build -t ruby .
+	cd ./ruby; docker build -t ruby .
 	docker tag ruby theconversation/ruby:latest
 
 sfdx:
-	cd sfdx; docker build -t sfdx .
+	cd ./sfdx; docker build -t sfdx .
 	docker tag sfdx theconversation/sfdx:latest
 
 push:

--- a/Makefile
+++ b/Makefile
@@ -6,27 +6,35 @@ base:
 	pwd
 	cd ./base; docker build -t base .
 	docker tag base theconversation/base:latest
+	docker tag base theconversation/base:alpine3.11
 
 node:
 	cd ./node; docker build -t node .
 	docker tag node theconversation/node:latest
+	docker tag node theconversation/node:alpine3.11
 
 ruby:
 	cd ./ruby; docker build -t ruby .
 	docker tag ruby theconversation/ruby:latest
+	docker tag ruby theconversation/ruby:alpine3.11
 
 sfdx:
 	cd ./sfdx; docker build -t sfdx .
 	docker tag sfdx theconversation/sfdx:latest
+	docker tag sfdx theconversation/sfdx:alpine3.11
 
 push:
 	docker push theconversation/base:latest
+	docker push theconversation/base:alpine3.11
 	docker push theconversation/node:latest
+	docker push theconversation/node:alpine3.11
 	docker push theconversation/ruby:latest
+	docker push theconversation/ruby:alpine3.11
 	docker push theconversation/sfdx:latest
+	docker push theconversation/sfdx:alpine3.11
 
 clobber:
-	docker rmi base theconversation/base:latest
-	docker rmi node theconversation/node:latest
-	docker rmi ruby theconversation/ruby:latest
-	docker rmi sfdx theconversation/sfdx:latest
+	docker rmi base theconversation/base
+	docker rmi node theconversation/node
+	docker rmi ruby theconversation/ruby
+	docker rmi sfdx theconversation/sfdx

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9.4
+FROM alpine:3.11.2
 
 # Install core packages.
 RUN apk --no-cache add curl git jq libbz2 libpq libxml2 zlib

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM theconversation/base
+FROM theconversation/base:alpine3.11
 
 # Install node.
 RUN apk --no-cache add npm nodejs

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM theconversation/base
+FROM theconversation/base:alpine3.11
 
 # Install ruby and postgres client.
 RUN apk --no-cache add ruby-dev ruby-full ruby-bundler

--- a/sfdx/Dockerfile
+++ b/sfdx/Dockerfile
@@ -1,4 +1,4 @@
-FROM theconversation/node AS ci
+FROM theconversation/node:alpine3.11 AS ci
 
 # Install the SFDX CLI client for SalesForce
 RUN npm install --global sfdx-cli@6.37.0


### PR DESCRIPTION
The 3.11 release of Alpine Linux contains the postgres 12 utilities (pg_dump, etc.), which are required to connect to the latest postgres server.

I have started tagging the docker images with the version of alpine we are using (e.g. `alpine3.11`). This way our apps can target a specific version of alpine, and won't be accidentally upgraded.

See:

* https://github.com/conversation/tc-counter/pull/259
* https://github.com/conversation/tc-data-warehouse/pull/861