### PR TITLE
Add Ubuntu based Ruby 2.4 image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: all base node ruby sfdx
+.PHONY: all base node ruby ruby-ubuntu sfdx
 
-all: base ruby node sfdx
+all: base ruby ruby-ubuntu node sfdx
 
 base:
 	pwd
@@ -18,6 +18,11 @@ ruby:
 	docker tag ruby theconversation/ruby:latest
 	docker tag ruby theconversation/ruby:alpine3.11
 
+ruby-ubuntu:
+	cd $@; docker build -t $@ .
+	docker tag $@ theconversation/ruby:latest-ubuntu-xenial
+	docker tag $@ theconversation/ruby:2.4-ubuntu-xenial
+
 sfdx:
 	cd ./sfdx; docker build -t sfdx .
 	docker tag sfdx theconversation/sfdx:latest
@@ -30,6 +35,8 @@ push:
 	docker push theconversation/node:alpine3.11
 	docker push theconversation/ruby:latest
 	docker push theconversation/ruby:alpine3.11
+	docker push theconversation/ruby:latest-ubuntu-xenial
+	docker push theconversation/ruby:2.4-ubuntu-xenial
 	docker push theconversation/sfdx:latest
 	docker push theconversation/sfdx:alpine3.11
 

--- a/ruby-ubuntu/Dockerfile
+++ b/ruby-ubuntu/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:xenial
+
+RUN apt-get update \
+      && apt-get install -y --no-install-recommends software-properties-common wget \
+      && add-apt-repository -y ppa:brightbox/ruby-ng \
+      && add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" \
+      && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+      && apt-get update \
+      && apt-get install -y --no-install-recommends \
+        build-essential \
+        pkg-config \
+        curl \
+        git \
+        zlib1g-dev \
+        libxml2-dev libxslt-dev \
+        ruby2.4 ruby2.4-dev \
+        tzdata \
+        locales \
+      && locale-gen en_AU.UTF-8 \
+      && rm -rf /var/lib/apt/lists/*
+
+ENV LANG=en_AU.UTF-8 \
+    LC_ALL=en_AU.UTF-8
+
+RUN gem install bundler --version "1.17.3" \
+      && echo "install: --no-rdoc --no-ri" > /etc/gemrc
+
+RUN bundle config build.nokogiri --use-system-libraries


### PR DESCRIPTION
For instances where we want test parity with our Ubuntu based Ruby deployments we'd like an alternative to the existing alpine image.

This provides that. It installs a few common packages, including the appropriate system libraries for nokogiri. en_AU.UTF-8 is configured as the default language. The postgres apt repository is configured but we do not install anything from it.