### PR TITLE
Build Ruby 2.6 base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ruby:
 ruby-ubuntu:
 	cd $@; docker build -t $@ .
 	docker tag $@ theconversation/ruby:latest-ubuntu-xenial
-	docker tag $@ theconversation/ruby:2.4-ubuntu-xenial
+	docker tag $@ theconversation/ruby:2.6-ubuntu-xenial
 
 sfdx:
 	cd ./sfdx; docker build -t sfdx .
@@ -36,7 +36,7 @@ push:
 	docker push theconversation/ruby:latest
 	docker push theconversation/ruby:alpine3.11
 	docker push theconversation/ruby:latest-ubuntu-xenial
-	docker push theconversation/ruby:2.4-ubuntu-xenial
+	docker push theconversation/ruby:2.6-ubuntu-xenial
 	docker push theconversation/sfdx:latest
 	docker push theconversation/sfdx:alpine3.11
 

--- a/ruby-ubuntu/Dockerfile
+++ b/ruby-ubuntu/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
         git \
         zlib1g-dev \
         libxml2-dev libxslt-dev \
-        ruby2.4 ruby2.4-dev \
+        ruby2.6 ruby2.6-dev \
         tzdata \
         locales \
       && locale-gen en_AU.UTF-8 \


### PR DESCRIPTION
Support for Ruby 2.4 has now ended, which means:

> Bug and security fixes from more recent Ruby versions will no longer be backported to 2.4, and no further patch release of 2.4 will be released.

https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/

That's a problem for us, so we want to upgrade to a supported version of Ruby.

For now we want to keep using our Ubuntu 16.04 base, so we'll keep using Ruby from the brightbox PPA. This PPA provides a Ruby 2.6 package but not one for 2.7 yet, so we'll start by upgrading to Ruby 2.6.

https://launchpad.net/~brightbox/+archive/ubuntu/ruby-ng
https://www.ruby-lang.org/en/news/2017/12/25/ruby-2-5-0-released/
https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/

This provides Ruby 2.6.5; there's no package for 2.6.6 yet: https://groups.google.com/forum/#!topic/brightbox-ruby-ubuntu-packaging/r3_wJeDdleI