### PR TITLE
Build bundler 2 into ruby-ubuntu image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ruby:
 ruby-ubuntu:
 	cd $@; docker build -t $@ .
 	docker tag $@ theconversation/ruby:latest-ubuntu-xenial
-	docker tag $@ theconversation/ruby:2.6-ubuntu-xenial
+	docker tag $@ theconversation/ruby:2.6-ubuntu-xenial-20200714
 
 sfdx:
 	cd ./sfdx; docker build -t sfdx .
@@ -36,7 +36,7 @@ push:
 	docker push theconversation/ruby:latest
 	docker push theconversation/ruby:alpine3.11
 	docker push theconversation/ruby:latest-ubuntu-xenial
-	docker push theconversation/ruby:2.6-ubuntu-xenial
+	docker push theconversation/ruby:2.6-ubuntu-xenial-20200714
 	docker push theconversation/sfdx:latest
 	docker push theconversation/sfdx:alpine3.11
 

--- a/ruby-ubuntu/Dockerfile
+++ b/ruby-ubuntu/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
 ENV LANG=en_AU.UTF-8 \
     LC_ALL=en_AU.UTF-8
 
-RUN gem install bundler --version "1.17.3" \
+RUN gem install bundler --version "2.1.4" \
       && echo "install: --no-rdoc --no-ri" > /etc/gemrc
 
 RUN bundle config build.nokogiri --use-system-libraries


### PR DESCRIPTION
Bundler 2 was released in January 2019, and we'd like to upgrade to it to stay on top of things.

> This release focuses on removing offical support of versions of Ruby
> and RubyGems that have reached their end of life, with a few other small
> breaking changes.
>
> The following is the full list of changes to Bundler 2:
>
> * Removed support for Ruby < 2.3
> * Removed support for RubyGems < 3.0.0
> * Changed the github: 'some/repo' gem source to use the https schema by default
> * Errors/warnings will now print to STDERR
> * Bundler now auto-switches between version 1 and 2 based on the Lockfile

https://bundler.io/blog/2019/01/03/announcing-bundler-2.html

This installs the current release (2.1.4) in our ruby-ubuntu image. To distinguish it from the prior image we'll add the date to the image tag.