### PR TITLE
Build node 12.17.0 image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ base:
 	pwd
 	cd ./base; docker build -t base .
 	docker tag base theconversation/base:latest
-	docker tag base theconversation/base:alpine3.11
+	docker tag base theconversation/base:alpine3.12
 
 node:
 	cd ./node; docker build -t node .
@@ -30,7 +30,7 @@ sfdx:
 
 push:
 	docker push theconversation/base:latest
-	docker push theconversation/base:alpine3.11
+	docker push theconversation/base:alpine3.12
 	docker push theconversation/node:latest
 	docker push theconversation/node:alpine3.11
 	docker push theconversation/ruby:latest

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ base:
 node:
 	cd ./node; docker build -t node .
 	docker tag node theconversation/node:latest
-	docker tag node theconversation/node:alpine3.11
+	docker tag node theconversation/node:12.17.0
 
 ruby:
 	cd ./ruby; docker build -t ruby .
@@ -32,7 +32,7 @@ push:
 	docker push theconversation/base:latest
 	docker push theconversation/base:alpine3.12
 	docker push theconversation/node:latest
-	docker push theconversation/node:alpine3.11
+	docker push theconversation/node:12.17.0
 	docker push theconversation/ruby:latest
 	docker push theconversation/ruby:alpine3.11
 	docker push theconversation/ruby:latest-ubuntu-xenial

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11.2
+FROM alpine:3.12.0
 
 # Install core packages.
 RUN apk --no-cache add curl git jq libbz2 libpq libxml2 zlib

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM theconversation/base:alpine3.11
+FROM theconversation/base:alpine3.12
 
 # Install node.
-RUN apk --no-cache add npm nodejs
+RUN apk --no-cache add npm nodejs=12.17.0-r0


### PR DESCRIPTION
Our current image provides nodejs 12.14.0. We'd like to upgrade to take advantage of some enhancements to memory management, which may help with what may be a leak in one application.

This also starts tagging the image with the node version rather than the alpine one; this makes it a bit easier to see at a glance what's being provided and should be considered an immutable tag.

See:
* https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md
* https://github.com/nodejs/node/pull/27345

To do this we need to build an alpine 3.12 base image. The latest LTS version of nodejs is 12.18.2. alpine 3.11 provides nodejs 12.15, and alpine 3.12 provides 12.17.

See:
* https://alpinelinux.org/posts/Alpine-3.12.0-released.html
* https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.12.0