### PR TITLE
Build Ruby 2.7 base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ruby:
 ruby-ubuntu:
 	cd $@; docker build -t $@ .
 	docker tag $@ theconversation/ruby:latest-ubuntu-xenial
-	docker tag $@ theconversation/ruby:2.6-ubuntu-xenial-20200714
+	docker tag $@ theconversation/ruby:2.7-ubuntu-xenial-20200714
 
 sfdx:
 	cd ./sfdx; docker build -t sfdx .

--- a/ruby-ubuntu/Dockerfile
+++ b/ruby-ubuntu/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
         git \
         zlib1g-dev \
         libxml2-dev libxslt-dev \
-        ruby2.6 ruby2.6-dev \
+        ruby2.7 ruby2.7-dev \
         tzdata \
         locales \
       && locale-gen en_AU.UTF-8 \


### PR DESCRIPTION
Ruby 3.0 was released on December 25, 2020. We're currently using Ruby 2.6, which is two years old now. While we don't have a pressing need to upgrade to 2.7 like we did when moving away from 2.4, it's generally good for us to stay on top of these things.

The Ruby 3.0 release blog post mentions that:

> In principle, code that prints a warning on Ruby 2.7 won’t work

Which is also a good motivation for us to make the upgrade gradually - we probably won't get to 3.0 anytime soon, but we can make that future upgrade smaller by getting on 2.7 first.

See:
* https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/
* https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/
